### PR TITLE
Fix bug in RecentActivityView identifier syntax

### DIFF
--- a/HabitsApp/Views/RecentActivityView.swift
+++ b/HabitsApp/Views/RecentActivityView.swift
@@ -17,7 +17,7 @@ struct RecentActivityView: View {
             if sortedActivities.isEmpty {
                 Text("No activities yet").foregroundColor(.gray).padding()
             } else {
-                ForEach(sortedActivities.prefix(3), id: \ .habit.id) { activity in
+                ForEach(sortedActivities.prefix(3), id: \.habit.id) { activity in
                     ActivityRow(habit: activity.habit) {
                         habitToDelete = activity.habit
                         showingDeleteAlert = true


### PR DESCRIPTION
## Summary
- fix `ForEach` identifier syntax in `RecentActivityView`

## Testing
- `swift --version`

------
https://chatgpt.com/codex/tasks/task_e_685478b1da788332b4c7ad14c6f78d03