### PR TITLE
Add habits JSON config loader

### DIFF
--- a/HabitsApp/HabitsAppApp.swift
+++ b/HabitsApp/HabitsAppApp.swift
@@ -5,13 +5,7 @@ struct HabitsAppApp: App {
     @StateObject private var viewModel: HabitViewModel
 
     init() {
-        let initialHabits = [
-            Habit(name: "Drink Water", points: 2,  type: .good, category: "Health"),
-            Habit(name: "Meditate",    points:10, type: .good, category: "Mindfulness"),
-            Habit(name: "Workout",     points:15, type: .good, category: "Fitness"),
-            Habit(name: "Junk Food",   points:-10,type: .bad,  category: "Diet"),
-            Habit(name: "Procrastinate", points:-5, type: .bad, category: "Productivity")
-        ]
+        let initialHabits = HabitConfigLoader.load()
         let repository = FileHabitRepository(initialHabits: initialHabits)
         let service    = HabitService(repository: repository)
         _viewModel     = StateObject(wrappedValue: HabitViewModel(service: service))

--- a/HabitsApp/Services/HabitConfigLoader.swift
+++ b/HabitsApp/Services/HabitConfigLoader.swift
@@ -1,0 +1,18 @@
+import Foundation
+
+struct HabitConfigLoader {
+    static func load(from fileName: String = "initial_habits.json") -> [Habit] {
+        guard let url = Bundle.main.url(forResource: fileName, withExtension: nil) else {
+            print("[HabitConfigLoader] Could not find \(fileName) in bundle")
+            return []
+        }
+        do {
+            let data = try Data(contentsOf: url)
+            let habits = try JSONDecoder().decode([Habit].self, from: data)
+            return habits
+        } catch {
+            print("[HabitConfigLoader] Failed to load habits: \(error)")
+            return []
+        }
+    }
+}

--- a/HabitsApp/initial_habits.json
+++ b/HabitsApp/initial_habits.json
@@ -1,0 +1,7 @@
+[
+  {"name":"Drink Water","points":2,"type":"Good Habit","category":"Health"},
+  {"name":"Meditate","points":10,"type":"Good Habit","category":"Mindfulness"},
+  {"name":"Workout","points":15,"type":"Good Habit","category":"Fitness"},
+  {"name":"Junk Food","points":-10,"type":"Bad Habit","category":"Diet"},
+  {"name":"Procrastinate","points":-5,"type":"Bad Habit","category":"Productivity"}
+]

--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # habits
 
+This app loads its list of default habits from `initial_habits.json` located in
+`HabitsApp/`. Edit this file to change the habits without modifying source code.
+
 
 
 ## Getting started


### PR DESCRIPTION
## Summary
- add `initial_habits.json` with default habit data
- add `HabitConfigLoader` to read habit data from a JSON file
- load habits through the loader in `HabitsAppApp`
- document config file usage in README

## Testing
- `swift build` *(fails: Could not find Package.swift)*
- `xcodebuild -list` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6854792b82a883329b9b5486e8779b3b