### PR TITLE
Add units and new activities

### DIFF
--- a/HabitsApp/Models/Habit.swift
+++ b/HabitsApp/Models/Habit.swift
@@ -11,12 +11,16 @@ struct Habit: Identifiable, Hashable, Codable {
     let points: Int
     let type: HabitType
     let category: String
+    let value: Int?
+    let unit: String?
 
-    init(id: UUID = UUID(), name: String, points: Int, type: HabitType, category: String) {
+    init(id: UUID = UUID(), name: String, points: Int, type: HabitType, category: String, value: Int? = nil, unit: String? = nil) {
         self.id = id
         self.name = name
         self.points = points
         self.type = type
         self.category = category
+        self.value = value
+        self.unit = unit
     }
 }

--- a/HabitsApp/Services/HabitConfigLoader.swift
+++ b/HabitsApp/Services/HabitConfigLoader.swift
@@ -4,11 +4,14 @@ struct HabitConfigLoader {
 
     /// Fallback habits used when a configuration file cannot be loaded.
     private static let builtInHabits: [Habit] = [
-        Habit(name: "Drink Water",    points: 2,  type: .good, category: "Health"),
-        Habit(name: "Meditate",       points: 10, type: .good, category: "Mindfulness"),
-        Habit(name: "Workout",        points: 15, type: .good, category: "Fitness"),
+        Habit(name: "Drink Water",    points: 2,  type: .good, category: "Health",       value: 1,  unit: "cup"),
+        Habit(name: "Meditate",       points: 10, type: .good, category: "Mindfulness", value: 15, unit: "minutes"),
+        Habit(name: "Workout",        points: 15, type: .good, category: "Fitness",     value: 30, unit: "minutes"),
+        Habit(name: "Read Book",      points: 5,  type: .good, category: "Mindfulness", value: 20, unit: "pages"),
+        Habit(name: "Walk",           points: 5,  type: .good, category: "Fitness",     value: 1,  unit: "mile"),
         Habit(name: "Junk Food",      points: -10, type: .bad, category: "Diet"),
-        Habit(name: "Procrastinate", points: -5, type: .bad, category: "Productivity")
+        Habit(name: "Procrastinate", points: -5,  type: .bad, category: "Productivity"),
+        Habit(name: "Smoke",          points: -15, type: .bad, category: "Health")
     ]
 
     static func load(from fileName: String = "initial_habits.json") -> [Habit] {

--- a/HabitsApp/Views/ActivityRow.swift
+++ b/HabitsApp/Views/ActivityRow.swift
@@ -7,10 +7,13 @@ struct ActivityRow: View {
         HStack {
             Image(systemName: habit.type == .good ? "checkmark.circle.fill" : "xmark.circle.fill")
                 .foregroundColor(habit.type == .good ? .green : .red)
-            if let value = habit.value, let unit = habit.unit {
-                Text("\(habit.name) (\(value) \(unit))")
-            } else {
+            VStack(alignment: .leading) {
                 Text(habit.name)
+                if let value = habit.value, let unit = habit.unit {
+                    Text("\(value) \(unit)")
+                        .font(.caption)
+                        .foregroundColor(.secondary)
+                }
             }
             Spacer()
             Text("\(habit.points > 0 ? "+" : "")\(habit.points) pts")

--- a/HabitsApp/Views/ActivityRow.swift
+++ b/HabitsApp/Views/ActivityRow.swift
@@ -7,7 +7,11 @@ struct ActivityRow: View {
         HStack {
             Image(systemName: habit.type == .good ? "checkmark.circle.fill" : "xmark.circle.fill")
                 .foregroundColor(habit.type == .good ? .green : .red)
-            Text(habit.name)
+            if let value = habit.value, let unit = habit.unit {
+                Text("\(habit.name) (\(value) \(unit))")
+            } else {
+                Text(habit.name)
+            }
             Spacer()
             Text("\(habit.points > 0 ? "+" : "")\(habit.points) pts")
                 .bold().foregroundColor(habit.points > 0 ? .green : .red)

--- a/HabitsApp/Views/DailyProgressView.swift
+++ b/HabitsApp/Views/DailyProgressView.swift
@@ -135,25 +135,9 @@ struct DailyProgressView: View {
                         }
 
                         ForEach(entry.habits, id: \.id) { habit in
-                            HStack {
-                                Image(systemName: habit.type == .good ? "plus.circle.fill" : "minus.circle.fill")
-                                    .foregroundColor(habit.type == .good ? .green : .red)
-                                if let value = habit.value, let unit = habit.unit {
-                                    Text("\(habit.name) (\(value) \(unit))")
-                                } else {
-                                    Text(habit.name)
-                                }
-                                Spacer()
-                                Text("\(habit.points > 0 ? "+" : "")\(habit.points) pts")
-                                    .foregroundColor(habit.points > 0 ? .green : .red)
-                                Button(action: {
-                                    habitToDelete = habit
-                                    showingDeleteAlert = true
-                                }) {
-                                    Image(systemName: "xmark.circle.fill")
-                                        .foregroundColor(.red)
-                                }
-                                .buttonStyle(BorderlessButtonStyle())
+                            ActivityRow(habit: habit) {
+                                habitToDelete = habit
+                                showingDeleteAlert = true
                             }
                         }
                     }

--- a/HabitsApp/Views/DailyProgressView.swift
+++ b/HabitsApp/Views/DailyProgressView.swift
@@ -138,7 +138,11 @@ struct DailyProgressView: View {
                             HStack {
                                 Image(systemName: habit.type == .good ? "plus.circle.fill" : "minus.circle.fill")
                                     .foregroundColor(habit.type == .good ? .green : .red)
-                                Text(habit.name)
+                                if let value = habit.value, let unit = habit.unit {
+                                    Text("\(habit.name) (\(value) \(unit))")
+                                } else {
+                                    Text(habit.name)
+                                }
                                 Spacer()
                                 Text("\(habit.points > 0 ? "+" : "")\(habit.points) pts")
                                     .foregroundColor(habit.points > 0 ? .green : .red)

--- a/HabitsApp/Views/HabitSelectionView.swift
+++ b/HabitsApp/Views/HabitSelectionView.swift
@@ -52,7 +52,11 @@ struct HabitSelectionView: View {
                                 Image(systemName: habit.type == .good
                                       ? "plus.circle.fill" : "minus.circle.fill")
                                     .foregroundColor(habit.type == .good ? .green : .red)
-                                Text(habit.name)
+                                if let value = habit.value, let unit = habit.unit {
+                                    Text("\(habit.name) (\(value) \(unit))")
+                                } else {
+                                    Text(habit.name)
+                                }
                                 Spacer()
                                 Text("\(habit.points > 0 ? "+" : "")\(habit.points) pts")
                                     .bold()

--- a/HabitsApp/initial_habits.json
+++ b/HabitsApp/initial_habits.json
@@ -1,7 +1,10 @@
 [
-  {"name":"Drink Water","points":2,"type":"Good Habit","category":"Health"},
-  {"name":"Meditate","points":10,"type":"Good Habit","category":"Mindfulness"},
-  {"name":"Workout","points":15,"type":"Good Habit","category":"Fitness"},
+  {"name":"Drink Water","points":2,"type":"Good Habit","category":"Health","value":1,"unit":"cup"},
+  {"name":"Meditate","points":10,"type":"Good Habit","category":"Mindfulness","value":15,"unit":"minutes"},
+  {"name":"Workout","points":15,"type":"Good Habit","category":"Fitness","value":30,"unit":"minutes"},
+  {"name":"Read Book","points":5,"type":"Good Habit","category":"Mindfulness","value":20,"unit":"pages"},
+  {"name":"Walk","points":5,"type":"Good Habit","category":"Fitness","value":1,"unit":"mile"},
   {"name":"Junk Food","points":-10,"type":"Bad Habit","category":"Diet"},
-  {"name":"Procrastinate","points":-5,"type":"Bad Habit","category":"Productivity"}
+  {"name":"Procrastinate","points":-5,"type":"Bad Habit","category":"Productivity"},
+  {"name":"Smoke","points":-15,"type":"Bad Habit","category":"Health"}
 ]


### PR DESCRIPTION
## Summary
- extend the `Habit` model with optional `value` and `unit`
- show these details in `ActivityRow`, `DailyProgressView` and `HabitSelectionView`
- expand the built‑in habits and `initial_habits.json` with new activities that include units

## Testing
- `swift --version`

------
https://chatgpt.com/codex/tasks/task_e_6854812614c08332aab58d7efdbc21cb