### PR TITLE
Update home screen header

### DIFF
--- a/HabitsApp/Services/HabitService.swift
+++ b/HabitsApp/Services/HabitService.swift
@@ -38,6 +38,12 @@ class HabitService {
             .reduce(0) { $0 + $1.key.points }
     }
 
+    /// Total points accumulated across all time
+    func totalPointsAllTime() -> Int {
+        repository.fetchCompletedHabits()
+            .reduce(0) { $0 + $1.key.points }
+    }
+
     /// Fractional progress toward daily target
     func dailyProgress() -> Double {
         min(Double(totalPointsToday()) / dailyTarget, 1.0)

--- a/HabitsApp/ViewModels/HabitViewModel.swift
+++ b/HabitsApp/ViewModels/HabitViewModel.swift
@@ -5,10 +5,15 @@ import Combine
 /// Protocol to abstract key–value storage for user info
 protocol KeyValueStore {
     func string(forKey key: String) -> String?
+    func integer(forKey key: String) -> Int
     func set(_ value: Any?, forKey key: String)
 }
 
-extension UserDefaults: KeyValueStore {}
+extension UserDefaults: KeyValueStore {
+    func integer(forKey key: String) -> Int {
+        object(forKey: key) as? Int ?? 0
+    }
+}
 
 /// A user achievement/trophy
 struct Achievement: Identifiable {
@@ -22,6 +27,7 @@ struct Achievement: Identifiable {
 class HabitViewModel: ObservableObject {
     // MARK: - Published State
     @Published var totalPoints: Int = 0
+    @Published var gems: Int = 0
     @Published var dailyProgress: Double = 0.0
     @Published var categories: [String] = []
     @Published var dailyHistory: [(date: Date, habits: [Habit])] = []
@@ -45,13 +51,14 @@ class HabitViewModel: ObservableObject {
         self.store   = store
         self.userName  = store.string(forKey: "userName")  ?? ""
         self.userEmail = store.string(forKey: "userEmail") ?? ""
+        self.gems      = store.integer(forKey: "gems")
         setupAchievements()
         reloadAll()
     }
 
     // MARK: - Data Loading
     func reloadAll() {
-        totalPoints   = service.totalPointsToday()
+        totalPoints   = service.totalPointsAllTime()
         dailyProgress = service.dailyProgress()
         categories    = service.categories()
         dailyHistory  = service.dailyHistory()

--- a/HabitsApp/Views/ContentView.swift
+++ b/HabitsApp/Views/ContentView.swift
@@ -54,7 +54,9 @@ struct ContentView: View {
                     }
                     .padding()
                 }
-                .navigationTitle("Today")
+                .navigationTitle("")
+                .navigationBarHidden(true)
+                .navigationBarTitleDisplayMode(.inline)
                 .sheet(isPresented: $showingHabitList) {
                     HabitSelectionView(
                         selectedCategory: $selectedCategory,

--- a/HabitsApp/Views/MainView.swift
+++ b/HabitsApp/Views/MainView.swift
@@ -6,7 +6,7 @@ struct MainView: View {
     var body: some View {
         TabView {
             ContentView()
-                .tabItem { Label("Today",     systemImage: "house.fill") }
+                .tabItem { Label("Home",      systemImage: "house.fill") }
 
             InsightsView()
                 .tabItem { Label("Insights",  systemImage: "chart.bar.fill") }

--- a/HabitsApp/Views/ProfileHeader.swift
+++ b/HabitsApp/Views/ProfileHeader.swift
@@ -4,25 +4,47 @@ struct ProfileHeader: View {
     @EnvironmentObject var viewModel: HabitViewModel
 
     var body: some View {
-        HStack {
-            Image(systemName: "person.circle.fill")
-                .resizable()
-                .frame(width: 60, height: 60)
-                .foregroundColor(.blue)
+        VStack(alignment: .leading, spacing: 12) {
+            HStack {
+                Image(systemName: "person.circle.fill")
+                    .resizable()
+                    .frame(width: 60, height: 60)
+                    .foregroundColor(.blue)
 
-            VStack(alignment: .leading) {
-                if viewModel.userName.isEmpty {
-                    Text("Welcome")
-                        .font(.headline)
-                } else {
-                    Text("Hello, \(viewModel.userName)")
+                VStack(alignment: .leading) {
+                    if viewModel.userName.isEmpty {
+                        Text("Welcome")
+                            .font(.headline)
+                    } else {
+                        Text("Hello, \(viewModel.userName)")
+                            .font(.headline)
+                    }
+                    Text("Your Progress")
+                        .font(.subheadline)
+                        .foregroundColor(.secondary)
+                }
+                Spacer()
+            }
+
+            HStack(spacing: 30) {
+                VStack(alignment: .leading) {
+                    Text("Points")
+                        .font(.caption)
+                        .foregroundColor(.secondary)
+                    Text("\(viewModel.totalPoints)")
                         .font(.headline)
                 }
-                Text("Your Progress")
-                    .font(.subheadline)
-                    .foregroundColor(.secondary)
+
+                Spacer()
+
+                VStack(alignment: .leading) {
+                    Text("Gems")
+                        .font(.caption)
+                        .foregroundColor(.secondary)
+                    Text("\(viewModel.gems)")
+                        .font(.headline)
+                }
             }
-            Spacer()
         }
         .padding()
         .background(Color(.systemGray6))


### PR DESCRIPTION
## Summary
- add all-time points tracking and gem storage
- show points & gems in the profile header
- rename Today tab to Home
- hide the navigation title on the main view

## Testing
- `swift --version`
- `swiftc -emit-sil -o /tmp/main.sil HabitsApp/Views/MainView.swift` *(fails: no such module 'SwiftUI')*

------
https://chatgpt.com/codex/tasks/task_e_68548e2d0078833281a07c96e8b6d9e3