### PR TITLE
Add activity timestamp display

### DIFF
--- a/HabitsApp/ViewModels/HabitViewModel.swift
+++ b/HabitsApp/ViewModels/HabitViewModel.swift
@@ -92,6 +92,11 @@ class HabitViewModel: ObservableObject {
         reloadAll()
     }
 
+    /// Retrieve the completion date for a given habit, if available
+    func completionDate(for habit: Habit) -> Date? {
+        service.fetchCompletedHabitDates()[habit]
+    }
+
     // MARK: - User Registration
     func register(name: String, email: String) {
         userName  = name

--- a/HabitsApp/Views/ActivityRow.swift
+++ b/HabitsApp/Views/ActivityRow.swift
@@ -2,6 +2,7 @@ import SwiftUI
 
 struct ActivityRow: View {
     let habit: Habit
+    let date: Date?
     let onDelete: () -> Void
     var body: some View {
         HStack {
@@ -12,6 +13,11 @@ struct ActivityRow: View {
                 if let value = habit.value, let unit = habit.unit {
                     Text("\(value) \(unit)")
                         .font(.caption)
+                        .foregroundColor(.secondary)
+                }
+                if let d = date {
+                    Text(d, style: .time)
+                        .font(.caption2)
                         .foregroundColor(.secondary)
                 }
             }

--- a/HabitsApp/Views/DailyProgressView.swift
+++ b/HabitsApp/Views/DailyProgressView.swift
@@ -135,7 +135,7 @@ struct DailyProgressView: View {
                         }
 
                         ForEach(entry.habits, id: \.id) { habit in
-                            ActivityRow(habit: habit) {
+                            ActivityRow(habit: habit, date: viewModel.completionDate(for: habit)) {
                                 habitToDelete = habit
                                 showingDeleteAlert = true
                             }

--- a/HabitsApp/Views/HabitSelectionView.swift
+++ b/HabitsApp/Views/HabitSelectionView.swift
@@ -42,7 +42,15 @@ struct HabitSelectionView: View {
                         Button {
                             // Use the correct ViewModel methods
                             if let day = completionDate {
-                                viewModel.addCompletion(habit, at: day)
+                                // Preserve the selected day but use the current time
+                                let now = Date()
+                                var comps = Calendar.current.dateComponents([.year, .month, .day], from: day)
+                                let time = Calendar.current.dateComponents([.hour, .minute, .second], from: now)
+                                comps.hour = time.hour
+                                comps.minute = time.minute
+                                comps.second = time.second
+                                let timestamp = Calendar.current.date(from: comps) ?? day
+                                viewModel.addCompletion(habit, at: timestamp)
                             } else {
                                 viewModel.add(habit)
                             }

--- a/HabitsApp/Views/RecentActivityView.swift
+++ b/HabitsApp/Views/RecentActivityView.swift
@@ -7,7 +7,10 @@ struct RecentActivityView: View {
 
     var sortedActivities: [(habit: Habit, date: Date)] {
         viewModel.dailyHistory.flatMap { entry in
-            entry.habits.map { (habit: $0, date: entry.date) }
+            entry.habits.compactMap { habit in
+                guard let actual = viewModel.completionDate(for: habit) else { return nil }
+                return (habit: habit, date: actual)
+            }
         }.sorted { $0.date > $1.date }
     }
 
@@ -18,7 +21,7 @@ struct RecentActivityView: View {
                 Text("No activities yet").foregroundColor(.gray).padding()
             } else {
                 ForEach(sortedActivities.prefix(3), id: \.habit.id) { activity in
-                    ActivityRow(habit: activity.habit) {
+                    ActivityRow(habit: activity.habit, date: activity.date) {
                         habitToDelete = activity.habit
                         showingDeleteAlert = true
                     }


### PR DESCRIPTION
## Summary
- display completion time in `ActivityRow`
- expose `completionDate(for:)` helper on `HabitViewModel`
- show timestamps in `RecentActivityView` and `DailyProgressView`

## Testing
- `swift --version`

------
https://chatgpt.com/codex/tasks/task_e_6855ea966a388332a395b93dc8c7dce3