### PR TITLE
Add habit template editing features

### DIFF
--- a/HabitsApp/Repositories/FileHabitRepository.swift
+++ b/HabitsApp/Repositories/FileHabitRepository.swift
@@ -6,46 +6,94 @@ private struct HabitCompletion: Codable {
 }
 
 class FileHabitRepository: HabitRepository {
-    private let fileURL: URL
-    private let initialHabits: [Habit]
+    private let completionsURL: URL
+    private let templatesURL: URL
+    private var habits: [Habit]
     private var completed: [Habit: Date] = [:]
 
-    init(initialHabits: [Habit], filename: String = "habit_completions.json") {
-        self.initialHabits = initialHabits
+    init(initialHabits: [Habit],
+         completionsFilename: String = "habit_completions.json",
+         templatesFilename: String = "habit_templates.json") {
         let docs = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first!
-        self.fileURL = docs.appendingPathComponent(filename)
+        self.completionsURL = docs.appendingPathComponent(completionsFilename)
+        self.templatesURL = docs.appendingPathComponent(templatesFilename)
+        self.habits = initialHabits
         load()
     }
 
-    func fetchAllHabits() -> [Habit] { initialHabits }
+    func fetchAllHabits() -> [Habit] { habits }
     func fetchCompletedHabits() -> [Habit: Date] { completed }
     func saveCompletion(_ habit: Habit, at date: Date) {
         completed[habit] = date
-        save()
+        saveCompletions()
     }
     func deleteCompletion(_ habit: Habit) {
         completed.removeValue(forKey: habit)
-        save()
+        saveCompletions()
     }
 
-    private func load() {
-        guard FileManager.default.fileExists(atPath: fileURL.path) else { return }
-        do {
-            let data = try Data(contentsOf: fileURL)
-            let list = try JSONDecoder().decode([HabitCompletion].self, from: data)
-            completed = Dictionary(uniqueKeysWithValues: list.map { ($0.habit, $0.date) })
-        } catch {
-            print("[FileHabitRepository] Load error: \(error)")
+    // MARK: - Template Management
+    func addHabitTemplate(_ habit: Habit) {
+        habits.append(habit)
+        saveTemplates()
+    }
+
+    func updateHabitTemplate(_ habit: Habit) {
+        if let idx = habits.firstIndex(where: { $0.id == habit.id }) {
+            habits[idx] = habit
+            saveTemplates()
         }
     }
 
-    private func save() {
+    func removeHabitTemplate(_ habit: Habit) {
+        habits.removeAll { $0.id == habit.id }
+        completed.removeValue(forKey: habit)
+        saveTemplates()
+        saveCompletions()
+    }
+
+    private func load() {
+        loadCompletions()
+        loadTemplates()
+    }
+
+    private func loadCompletions() {
+        guard FileManager.default.fileExists(atPath: completionsURL.path) else { return }
+        do {
+            let data = try Data(contentsOf: completionsURL)
+            let list = try JSONDecoder().decode([HabitCompletion].self, from: data)
+            completed = Dictionary(uniqueKeysWithValues: list.map { ($0.habit, $0.date) })
+        } catch {
+            print("[FileHabitRepository] Load completions error: \(error)")
+        }
+    }
+
+    private func saveCompletions() {
         let list = completed.map { HabitCompletion(habit: $0.key, date: $0.value) }
         do {
             let data = try JSONEncoder().encode(list)
-            try data.write(to: fileURL, options: .atomic)
+            try data.write(to: completionsURL, options: .atomic)
         } catch {
-            print("[FileHabitRepository] Save error: \(error)")
+            print("[FileHabitRepository] Save completions error: \(error)")
+        }
+    }
+
+    private func loadTemplates() {
+        guard FileManager.default.fileExists(atPath: templatesURL.path) else { return }
+        do {
+            let data = try Data(contentsOf: templatesURL)
+            habits = try JSONDecoder().decode([Habit].self, from: data)
+        } catch {
+            print("[FileHabitRepository] Load templates error: \(error)")
+        }
+    }
+
+    private func saveTemplates() {
+        do {
+            let data = try JSONEncoder().encode(habits)
+            try data.write(to: templatesURL, options: .atomic)
+        } catch {
+            print("[FileHabitRepository] Save templates error: \(error)")
         }
     }
 }

--- a/HabitsApp/Repositories/HabitRepository.swift
+++ b/HabitsApp/Repositories/HabitRepository.swift
@@ -5,4 +5,9 @@ protocol HabitRepository {
     func fetchCompletedHabits() -> [Habit: Date]
     func saveCompletion(_ habit: Habit, at date: Date)
     func deleteCompletion(_ habit: Habit)
+
+    // Template management
+    func addHabitTemplate(_ habit: Habit)
+    func updateHabitTemplate(_ habit: Habit)
+    func removeHabitTemplate(_ habit: Habit)
 }

--- a/HabitsApp/Repositories/InMemoryHabitRepository.swift
+++ b/HabitsApp/Repositories/InMemoryHabitRepository.swift
@@ -13,4 +13,20 @@ class InMemoryHabitRepository: HabitRepository {
     func fetchCompletedHabits() -> [Habit: Date] { completed }
     func saveCompletion(_ habit: Habit, at date: Date) { completed[habit] = date }
     func deleteCompletion(_ habit: Habit) { completed.removeValue(forKey: habit) }
+
+    // MARK: - Template Management
+    func addHabitTemplate(_ habit: Habit) {
+        habits.append(habit)
+    }
+
+    func updateHabitTemplate(_ habit: Habit) {
+        if let idx = habits.firstIndex(where: { $0.id == habit.id }) {
+            habits[idx] = habit
+        }
+    }
+
+    func removeHabitTemplate(_ habit: Habit) {
+        habits.removeAll { $0.id == habit.id }
+        completed.removeValue(forKey: habit)
+    }
 }

--- a/HabitsApp/Services/HabitService.swift
+++ b/HabitsApp/Services/HabitService.swift
@@ -69,4 +69,17 @@ class HabitService {
     func fetchAllHabits() -> [Habit] {
         repository.fetchAllHabits()
     }
+
+    // MARK: - Template Management
+    func addHabitTemplate(_ habit: Habit) {
+        repository.addHabitTemplate(habit)
+    }
+
+    func updateHabitTemplate(_ habit: Habit) {
+        repository.updateHabitTemplate(habit)
+    }
+
+    func removeHabitTemplate(_ habit: Habit) {
+        repository.removeHabitTemplate(habit)
+    }
 }

--- a/HabitsApp/ViewModels/HabitViewModel.swift
+++ b/HabitsApp/ViewModels/HabitViewModel.swift
@@ -92,6 +92,22 @@ class HabitViewModel: ObservableObject {
         reloadAll()
     }
 
+    // MARK: - Habit Template Management
+    func addHabitTemplate(_ habit: Habit) {
+        service.addHabitTemplate(habit)
+        reloadAll()
+    }
+
+    func updateHabitTemplate(_ habit: Habit) {
+        service.updateHabitTemplate(habit)
+        reloadAll()
+    }
+
+    func removeHabitTemplate(_ habit: Habit) {
+        service.removeHabitTemplate(habit)
+        reloadAll()
+    }
+
     // MARK: - User Registration
     func register(name: String, email: String) {
         userName  = name

--- a/HabitsApp/ViewModels/HabitViewModel.swift
+++ b/HabitsApp/ViewModels/HabitViewModel.swift
@@ -108,6 +108,11 @@ class HabitViewModel: ObservableObject {
         reloadAll()
     }
 
+    /// Retrieve the completion date for a given habit, if available
+    func completionDate(for habit: Habit) -> Date? {
+        service.fetchCompletedHabitDates()[habit]
+    }
+
     // MARK: - User Registration
     func register(name: String, email: String) {
         userName  = name

--- a/HabitsApp/Views/ActivityRow.swift
+++ b/HabitsApp/Views/ActivityRow.swift
@@ -2,6 +2,7 @@ import SwiftUI
 
 struct ActivityRow: View {
     let habit: Habit
+    let date: Date?
     let onDelete: () -> Void
     var body: some View {
         HStack {
@@ -12,6 +13,11 @@ struct ActivityRow: View {
                 if let value = habit.value, let unit = habit.unit {
                     Text("\(value) \(unit)")
                         .font(.caption)
+                        .foregroundColor(.secondary)
+                }
+                if let d = date {
+                    Text(d, style: .time)
+                        .font(.caption2)
                         .foregroundColor(.secondary)
                 }
             }

--- a/HabitsApp/Views/DailyProgressView.swift
+++ b/HabitsApp/Views/DailyProgressView.swift
@@ -135,7 +135,7 @@ struct DailyProgressView: View {
                         }
 
                         ForEach(entry.habits, id: \.id) { habit in
-                            ActivityRow(habit: habit) {
+                            ActivityRow(habit: habit, date: viewModel.completionDate(for: habit)) {
                                 habitToDelete = habit
                                 showingDeleteAlert = true
                             }

--- a/HabitsApp/Views/HabitSelectionView.swift
+++ b/HabitsApp/Views/HabitSelectionView.swift
@@ -42,7 +42,15 @@ struct HabitSelectionView: View {
                         Button {
                             // Use the correct ViewModel methods
                             if let day = completionDate {
-                                viewModel.addCompletion(habit, at: day)
+                                // Preserve the selected day but use the current time
+                                let now = Date()
+                                var comps = Calendar.current.dateComponents([.year, .month, .day], from: day)
+                                let time = Calendar.current.dateComponents([.hour, .minute, .second], from: now)
+                                comps.hour = time.hour
+                                comps.minute = time.minute
+                                comps.second = time.second
+                                let timestamp = Calendar.current.date(from: comps) ?? day
+                                viewModel.addCompletion(habit, at: timestamp)
                             } else {
                                 viewModel.add(habit)
                             }

--- a/HabitsApp/Views/HabitTemplateFormView.swift
+++ b/HabitsApp/Views/HabitTemplateFormView.swift
@@ -10,16 +10,20 @@ struct HabitTemplateFormView: View {
     @State private var value: String
     @State private var unit: String
 
+    /// The list of available categories ("All" removed)
+    let categories: [String]
+
     let original: Habit?
     let onSave: (Habit) -> Void
 
-    init(habit: Habit?, onSave: @escaping (Habit) -> Void) {
+    init(habit: Habit?, categories: [String], onSave: @escaping (Habit) -> Void) {
         self.original = habit
+        self.categories = categories
         self.onSave = onSave
         _name = State(initialValue: habit?.name ?? "")
         _points = State(initialValue: habit?.points ?? 0)
         _type = State(initialValue: habit?.type ?? .good)
-        _category = State(initialValue: habit?.category ?? "")
+        _category = State(initialValue: habit?.category ?? categories.first ?? "")
         _value = State(initialValue: habit?.value.map { String($0) } ?? "")
         _unit = State(initialValue: habit?.unit ?? "")
     }
@@ -41,7 +45,11 @@ struct HabitTemplateFormView: View {
                             Text(type.rawValue).tag(type)
                         }
                     }
-                    TextField("Category", text: $category)
+                    Picker("Category", selection: $category) {
+                        ForEach(categories, id: \.self) { cat in
+                            Text(cat).tag(cat)
+                        }
+                    }
                     TextField("Value", text: $value)
                         .keyboardType(.numberPad)
                     TextField("Unit", text: $unit)

--- a/HabitsApp/Views/HabitTemplateFormView.swift
+++ b/HabitsApp/Views/HabitTemplateFormView.swift
@@ -1,0 +1,72 @@
+import SwiftUI
+
+struct HabitTemplateFormView: View {
+    @Environment(\.dismiss) private var dismiss
+
+    @State private var name: String
+    @State private var points: Int
+    @State private var type: HabitType
+    @State private var category: String
+    @State private var value: String
+    @State private var unit: String
+
+    let original: Habit?
+    let onSave: (Habit) -> Void
+
+    init(habit: Habit?, onSave: @escaping (Habit) -> Void) {
+        self.original = habit
+        self.onSave = onSave
+        _name = State(initialValue: habit?.name ?? "")
+        _points = State(initialValue: habit?.points ?? 0)
+        _type = State(initialValue: habit?.type ?? .good)
+        _category = State(initialValue: habit?.category ?? "")
+        _value = State(initialValue: habit?.value.map { String($0) } ?? "")
+        _unit = State(initialValue: habit?.unit ?? "")
+    }
+
+    var body: some View {
+        NavigationStack {
+            Form {
+                Section("Details") {
+                    TextField("Name", text: $name)
+                    Stepper(value: $points, in: -100...100) {
+                        HStack {
+                            Text("Points")
+                            Spacer()
+                            Text("\(points)")
+                        }
+                    }
+                    Picker("Type", selection: $type) {
+                        ForEach(HabitType.allCases, id: \.self) { type in
+                            Text(type.rawValue).tag(type)
+                        }
+                    }
+                    TextField("Category", text: $category)
+                    TextField("Value", text: $value)
+                        .keyboardType(.numberPad)
+                    TextField("Unit", text: $unit)
+                }
+            }
+            .navigationTitle(original == nil ? "Add Habit" : "Edit Habit")
+            .toolbar {
+                ToolbarItem(placement: .navigationBarLeading) {
+                    Button("Cancel") { dismiss() }
+                }
+                ToolbarItem(placement: .navigationBarTrailing) {
+                    Button("Save") {
+                        let val = Int(value)
+                        let habit = Habit(id: original?.id ?? UUID(),
+                                          name: name,
+                                          points: points,
+                                          type: type,
+                                          category: category,
+                                          value: val,
+                                          unit: unit.isEmpty ? nil : unit)
+                        onSave(habit)
+                        dismiss()
+                    }
+                }
+            }
+        }
+    }
+}

--- a/HabitsApp/Views/HabitTemplatesView.swift
+++ b/HabitsApp/Views/HabitTemplatesView.swift
@@ -1,0 +1,48 @@
+import SwiftUI
+
+struct HabitTemplatesView: View {
+    @EnvironmentObject private var viewModel: HabitViewModel
+    @State private var showAdd = false
+    @State private var editingHabit: Habit?
+
+    var body: some View {
+        NavigationStack {
+            List {
+                ForEach(viewModel.allHabits) { habit in
+                    HStack {
+                        Text(habit.name)
+                        Spacer()
+                        Text("\(habit.points)")
+                            .foregroundColor(habit.points >= 0 ? .green : .red)
+                    }
+                    .contentShape(Rectangle())
+                    .onTapGesture { editingHabit = habit }
+                }
+                .onDelete { indexSet in
+                    indexSet.forEach { idx in
+                        let habit = viewModel.allHabits[idx]
+                        viewModel.removeHabitTemplate(habit)
+                    }
+                }
+            }
+            .navigationTitle("Habit Templates")
+            .toolbar {
+                ToolbarItem(placement: .navigationBarTrailing) {
+                    Button(action: { showAdd = true }) {
+                        Image(systemName: "plus")
+                    }
+                }
+            }
+            .sheet(item: $editingHabit) { habit in
+                HabitTemplateFormView(habit: habit) { updated in
+                    viewModel.updateHabitTemplate(updated)
+                }
+            }
+            .sheet(isPresented: $showAdd) {
+                HabitTemplateFormView(habit: nil) { newHabit in
+                    viewModel.addHabitTemplate(newHabit)
+                }
+            }
+        }
+    }
+}

--- a/HabitsApp/Views/HabitTemplatesView.swift
+++ b/HabitsApp/Views/HabitTemplatesView.swift
@@ -34,12 +34,14 @@ struct HabitTemplatesView: View {
                 }
             }
             .sheet(item: $editingHabit) { habit in
-                HabitTemplateFormView(habit: habit) { updated in
+                let cats = Set(viewModel.categories.filter { $0 != "All" } + [habit.category]).sorted()
+                HabitTemplateFormView(habit: habit, categories: cats) { updated in
                     viewModel.updateHabitTemplate(updated)
                 }
             }
             .sheet(isPresented: $showAdd) {
-                HabitTemplateFormView(habit: nil) { newHabit in
+                let cats = viewModel.categories.filter { $0 != "All" }
+                HabitTemplateFormView(habit: nil, categories: cats) { newHabit in
                     viewModel.addHabitTemplate(newHabit)
                 }
             }

--- a/HabitsApp/Views/MainView.swift
+++ b/HabitsApp/Views/MainView.swift
@@ -13,6 +13,9 @@ struct MainView: View {
 
             AchievementsView()
                 .tabItem { Label("Trophies",  systemImage: "trophy.fill") }
+
+            HabitTemplatesView()
+                .tabItem { Label("Habits", systemImage: "list.bullet") }
         }
         .environmentObject(viewModel)
     }

--- a/HabitsApp/Views/RecentActivityView.swift
+++ b/HabitsApp/Views/RecentActivityView.swift
@@ -7,7 +7,10 @@ struct RecentActivityView: View {
 
     var sortedActivities: [(habit: Habit, date: Date)] {
         viewModel.dailyHistory.flatMap { entry in
-            entry.habits.map { (habit: $0, date: entry.date) }
+            entry.habits.compactMap { habit in
+                guard let actual = viewModel.completionDate(for: habit) else { return nil }
+                return (habit: habit, date: actual)
+            }
         }.sorted { $0.date > $1.date }
     }
 
@@ -18,7 +21,7 @@ struct RecentActivityView: View {
                 Text("No activities yet").foregroundColor(.gray).padding()
             } else {
                 ForEach(sortedActivities.prefix(3), id: \.habit.id) { activity in
-                    ActivityRow(habit: activity.habit) {
+                    ActivityRow(habit: activity.habit, date: activity.date) {
                         habitToDelete = activity.habit
                         showingDeleteAlert = true
                     }

--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ Make sure the file is included in your app bundle (add it to the Xcode project i
 If the file cannot be found or decoded, the app falls back to a built-in set of
 habits so the list is never empty.
 
+Habit templates can now be managed directly in the app. Open the **Habits** tab to add, edit, or remove templates. All changes are stored locally on disk.
+
 
 
 ## Getting started


### PR DESCRIPTION
## Summary
- support editing habit templates in repos, service, and view model
- persist template changes in FileHabitRepository
- add Habit Templates tab and editing UI
- document template editing in README

## Testing
- `swift --version`

------
https://chatgpt.com/codex/tasks/task_e_6855ebc5112c8332951be8593772cd98