### PR TITLE
Add swipe-to-delete for activity rows

### DIFF
--- a/HabitsApp/Views/ActivityRow.swift
+++ b/HabitsApp/Views/ActivityRow.swift
@@ -23,11 +23,16 @@ struct ActivityRow: View {
             }
             Spacer()
             Text("\(habit.points > 0 ? "+" : "")\(habit.points) pts")
-                .bold().foregroundColor(habit.points > 0 ? .green : .red)
-            Button(action: onDelete) {
-                Image(systemName: "xmark.circle.fill").foregroundColor(.red)
+                .bold()
+                .foregroundColor(habit.points > 0 ? .green : .red)
+        }
+        .padding()
+        .background(Color(.systemGray6))
+        .cornerRadius(8)
+        .swipeActions {
+            Button(role: .destructive, action: onDelete) {
+                Label("Delete", systemImage: "trash")
             }
         }
-        .padding().background(Color(.systemGray6)).cornerRadius(8)
     }
 }


### PR DESCRIPTION
## Summary
- remove the inline delete button from `ActivityRow`
- add a trailing swipe action to delete the row

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6855f2c0ea4c83329b921b1061733f2f