### PR TITLE
Add Daily progress tab

### DIFF
--- a/HabitsApp/Views/ContentView.swift
+++ b/HabitsApp/Views/ContentView.swift
@@ -39,7 +39,7 @@ struct ContentView: View {
                         ) {
                             HStack {
                                 Image(systemName: "calendar")
-                                Text("Daily Progress")
+                                Text("Daily")
                             }
                             .font(.headline)
                             .padding()

--- a/HabitsApp/Views/DailyProgressView.swift
+++ b/HabitsApp/Views/DailyProgressView.swift
@@ -144,7 +144,7 @@ struct DailyProgressView: View {
                 }
             }
             .listStyle(.insetGrouped)
-            .navigationTitle("Daily Progress")
+            .navigationTitle("Daily")
         }
         // MARK: – Add-sheet
         .sheet(isPresented: $showingAddSheet) {

--- a/HabitsApp/Views/MainView.swift
+++ b/HabitsApp/Views/MainView.swift
@@ -8,6 +8,9 @@ struct MainView: View {
             ContentView()
                 .tabItem { Label("Home",      systemImage: "house.fill") }
 
+            DailyProgressView()
+                .tabItem { Label("Daily",     systemImage: "calendar") }
+
             InsightsView()
                 .tabItem { Label("Insights",  systemImage: "chart.bar.fill") }
 


### PR DESCRIPTION
## Summary
- insert Daily progress view between Home and Insights
- shorten Daily progress button text to "Daily"
- match Daily progress navigation title to short name

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_6855f8484c7c8332baa144c4e314bc2e