### PR TITLE
Add unit tests for HabitService and HabitViewModel

### DIFF
--- a/HabitsAppTests/HabitServiceTests.swift
+++ b/HabitsAppTests/HabitServiceTests.swift
@@ -1,0 +1,38 @@
+import Foundation
+import Testing
+@testable import HabitsApp
+
+struct HabitServiceTests {
+    @Test func addAndRemoveCompletion() async throws {
+        let repo = InMemoryHabitRepository()
+        let provider = MockDateProvider(now: Date())
+        let service = HabitService(repository: repo, clock: provider)
+
+        let habit = Habit(name: "Test", points: 10, type: .good, category: "Gen")
+        service.addCompletion(habit)
+        #expect(repo.fetchCompletedHabits()[habit] != nil)
+        #expect(service.totalPointsToday() == 10)
+        #expect(service.dailyProgress() == 0.1)
+
+        service.removeCompletion(habit)
+        #expect(repo.fetchCompletedHabits()[habit] == nil)
+        #expect(service.totalPointsToday() == 0)
+        #expect(service.dailyProgress() == 0)
+    }
+
+    @Test func progressAcrossDays() async throws {
+        let repo = InMemoryHabitRepository()
+        let start = Date(timeIntervalSince1970: 0)
+        let provider = MockDateProvider(now: start)
+        let service = HabitService(repository: repo, clock: provider)
+        let habit = Habit(name: "Test", points: 50, type: .good, category: "Gen")
+
+        service.addCompletion(habit, at: start)
+        #expect(service.totalPointsToday() == 50)
+
+        provider.current = start.addingTimeInterval(86_400)
+        service.addCompletion(habit, at: provider.current)
+        #expect(service.totalPointsToday() == 50)
+        #expect(service.dailyProgress() == 0.5)
+    }
+}

--- a/HabitsAppTests/HabitViewModelTests.swift
+++ b/HabitsAppTests/HabitViewModelTests.swift
@@ -1,0 +1,55 @@
+import Foundation
+import Testing
+@testable import HabitsApp
+
+struct HabitViewModelTests {
+    @Test func addAndRemoveHabit() async throws {
+        let habit = Habit(name: "Water", points: 10, type: .good, category: "Health")
+        let repo = InMemoryHabitRepository(initialHabits: [habit])
+        let provider = MockDateProvider(now: Date())
+        let service = HabitService(repository: repo, clock: provider)
+        let vm = HabitViewModel(service: service, store: InMemoryStore())
+
+        vm.add(habit)
+        #expect(vm.totalPoints == 10)
+        #expect(vm.dailyProgress == 0.1)
+
+        vm.remove(habit)
+        #expect(vm.totalPoints == 0)
+        #expect(vm.dailyProgress == 0)
+    }
+
+    @Test func unlockStreakAchievement() async throws {
+        let habit = Habit(name: "Big", points: 100, type: .good, category: "Gen")
+        let repo = InMemoryHabitRepository(initialHabits: [habit])
+        let start = Date(timeIntervalSince1970: 0)
+        let provider = MockDateProvider(now: start)
+        let service = HabitService(repository: repo, clock: provider)
+        let vm = HabitViewModel(service: service, store: InMemoryStore())
+
+        for day in 0..<7 {
+            provider.current = start.addingTimeInterval(Double(day) * 86_400)
+            vm.addCompletion(habit, at: provider.current)
+        }
+
+        let ach = vm.achievements.first { $0.id == "streak80" }
+        #expect(ach?.unlockedDate != nil)
+    }
+
+    @Test func unlockWaterAchievement() async throws {
+        let habit = Habit(name: "Drink Water", points: 2, type: .good, category: "Health")
+        let repo = InMemoryHabitRepository(initialHabits: [habit])
+        let start = Date(timeIntervalSince1970: 0)
+        let provider = MockDateProvider(now: start)
+        let service = HabitService(repository: repo, clock: provider)
+        let vm = HabitViewModel(service: service, store: InMemoryStore())
+
+        for day in 0..<7 {
+            provider.current = start.addingTimeInterval(Double(day) * 86_400)
+            vm.addCompletion(habit, at: provider.current)
+        }
+
+        let ach = vm.achievements.first { $0.id == "water7" }
+        #expect(ach?.unlockedDate != nil)
+    }
+}

--- a/HabitsAppTests/TestHelpers.swift
+++ b/HabitsAppTests/TestHelpers.swift
@@ -1,0 +1,19 @@
+import Foundation
+@testable import HabitsApp
+
+final class MockDateProvider: DateProvider {
+    var current: Date
+    init(now: Date) { self.current = now }
+    var now: Date { current }
+    func startOfDay(for date: Date) -> Date {
+        Calendar.current.startOfDay(for: date)
+    }
+}
+
+final class InMemoryStore: KeyValueStore {
+    private var storage: [String: Any] = [:]
+    func string(forKey key: String) -> String? { storage[key] as? String }
+    func integer(forKey key: String) -> Int { storage[key] as? Int ?? 0 }
+    func dictionary(forKey key: String) -> [String : Any]? { storage[key] as? [String: Any] }
+    func set(_ value: Any?, forKey key: String) { storage[key] = value }
+}


### PR DESCRIPTION
## Summary
- test HabitService for adding/removing habits and progress calculations
- test HabitViewModel for habit actions and achievement unlocking
- provide helpers for mocking date and key-value storage
- attempt to run tests via `swift test`

## Testing
- `swift test --enable-test-discovery -Xswiftc -enable-testing` *(fails: Could not find Package.swift)*
- `xcodebuild test -scheme HabitsApp -destination 'platform=iOS Simulator,name=iPhone 14'` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6855fbdaf8c88332828b3ef869c7fe41