### PR TITLE
Add reminder notifications for habits

### DIFF
--- a/HabitsApp/Providers/NotificationManager.swift
+++ b/HabitsApp/Providers/NotificationManager.swift
@@ -1,0 +1,34 @@
+import Foundation
+import UserNotifications
+
+final class NotificationManager {
+    static let shared = NotificationManager()
+    private let center = UNUserNotificationCenter.current()
+
+    func requestAuthorization() {
+        center.requestAuthorization(options: [.alert, .sound, .badge]) { granted, error in
+            if let error = error {
+                print("[NotificationManager] auth error: \(error)")
+            } else if !granted {
+                print("[NotificationManager] permission not granted")
+            }
+        }
+    }
+
+    func schedule(id: String, title: String, body: String, at components: DateComponents) {
+        let content = UNMutableNotificationContent()
+        content.title = title
+        content.body = body
+        let trigger = UNCalendarNotificationTrigger(dateMatching: components, repeats: true)
+        let request = UNNotificationRequest(identifier: id, content: content, trigger: trigger)
+        center.add(request) { error in
+            if let error = error {
+                print("[NotificationManager] schedule error: \(error)")
+            }
+        }
+    }
+
+    func cancel(id: String) {
+        center.removePendingNotificationRequests(withIdentifiers: [id])
+    }
+}

--- a/HabitsApp/Views/HabitTemplateFormView.swift
+++ b/HabitsApp/Views/HabitTemplateFormView.swift
@@ -14,9 +14,10 @@ struct HabitTemplateFormView: View {
     let categories: [String]
 
     let original: Habit?
-    let onSave: (Habit) -> Void
-
-    init(habit: Habit?, categories: [String], onSave: @escaping (Habit) -> Void) {
+    let onSave: (Habit, DateComponents?) -> Void
+    @State private var reminderEnabled: Bool
+    @State private var reminderTime: Date
+    init(habit: Habit?, categories: [String], reminder: DateComponents?, onSave: @escaping (Habit, DateComponents?) -> Void) {
         self.original = habit
         self.categories = categories
         self.onSave = onSave
@@ -26,6 +27,9 @@ struct HabitTemplateFormView: View {
         _category = State(initialValue: habit?.category ?? categories.first ?? "")
         _value = State(initialValue: habit?.value.map { String($0) } ?? "")
         _unit = State(initialValue: habit?.unit ?? "")
+        let date = Calendar.current.date(from: reminder ?? DateComponents(hour: 9, minute: 0)) ?? Date()
+        _reminderEnabled = State(initialValue: reminder != nil)
+        _reminderTime = State(initialValue: date)
     }
 
     var body: some View {
@@ -54,6 +58,12 @@ struct HabitTemplateFormView: View {
                         .keyboardType(.numberPad)
                     TextField("Unit", text: $unit)
                 }
+                Section("Reminder") {
+                    Toggle("Enable", isOn: $reminderEnabled)
+                    if reminderEnabled {
+                        DatePicker("Time", selection: $reminderTime, displayedComponents: .hourAndMinute)
+                    }
+                }
             }
             .navigationTitle(original == nil ? "Add Habit" : "Edit Habit")
             .toolbar {
@@ -70,7 +80,8 @@ struct HabitTemplateFormView: View {
                                           category: category,
                                           value: val,
                                           unit: unit.isEmpty ? nil : unit)
-                        onSave(habit)
+                        let comps = reminderEnabled ? Calendar.current.dateComponents([.hour, .minute], from: reminderTime) : nil
+                        onSave(habit, comps)
                         dismiss()
                     }
                 }

--- a/HabitsApp/Views/HabitTemplatesView.swift
+++ b/HabitsApp/Views/HabitTemplatesView.swift
@@ -35,14 +35,22 @@ struct HabitTemplatesView: View {
             }
             .sheet(item: $editingHabit) { habit in
                 let cats = Set(viewModel.categories.filter { $0 != "All" } + [habit.category]).sorted()
-                HabitTemplateFormView(habit: habit, categories: cats) { updated in
+                HabitTemplateFormView(habit: habit, categories: cats, reminder: viewModel.reminderTime(for: habit)) { updated, comps in
                     viewModel.updateHabitTemplate(updated)
+                    if let c = comps, let date = Calendar.current.date(from: c) {
+                        viewModel.scheduleReminder(for: updated, time: date)
+                    } else {
+                        viewModel.removeReminder(for: updated)
+                    }
                 }
             }
             .sheet(isPresented: $showAdd) {
                 let cats = viewModel.categories.filter { $0 != "All" }
-                HabitTemplateFormView(habit: nil, categories: cats) { newHabit in
+                HabitTemplateFormView(habit: nil, categories: cats, reminder: nil) { newHabit, comps in
                     viewModel.addHabitTemplate(newHabit)
+                    if let c = comps, let date = Calendar.current.date(from: c) {
+                        viewModel.scheduleReminder(for: newHabit, time: date)
+                    }
                 }
             }
         }

--- a/README.md
+++ b/README.md
@@ -8,6 +8,10 @@ habits so the list is never empty.
 
 Habit templates can now be managed directly in the app. Open the **Habits** tab to add, edit, or remove templates. All changes are stored locally on disk.
 
+## Reminders
+
+You can schedule a daily notification for any habit. When adding or editing a habit template, enable the *Reminder* section and choose a time. The first time a reminder is scheduled the app will request permission to send notifications. Reminders repeat every day at the selected time.
+
 
 
 ## Getting started


### PR DESCRIPTION
## Summary
- implement `NotificationManager` for local notifications
- schedule habit reminders through `HabitViewModel`
- allow setting reminder time in `HabitTemplateFormView`
- wire reminder management in `HabitTemplatesView`
- document reminders in README

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_6855feb6ad608332b28ff0fef651477b